### PR TITLE
fix: use region slug instead of name for instance metadata

### DIFF
--- a/cherry/instances.go
+++ b/cherry/instances.go
@@ -81,7 +81,7 @@ func (i *instances) InstanceMetadata(_ context.Context, node *v1.Node) (*cloudpr
 	// Cherry Servers just have regions, which matchK8s topology regions. We do not have zones for now.
 	//
 	// https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone
-	r = server.Region.Name
+	r = server.Region.Slug
 
 	return &cloudprovider.InstanceMetadata{
 		ProviderID:    providerIDFromServer(server),

--- a/cherry/instances_test.go
+++ b/cherry/instances_test.go
@@ -211,7 +211,7 @@ func TestInstanceZone(t *testing.T) {
 		{"empty name", "", "", cloudprovider.InstanceNotFound},
 		{"invalid id", "thisdoesnotexist", "", fmt.Errorf("error converting")},
 		{"unknown name", fmt.Sprintf("%d", randomID), "", cloudprovider.InstanceNotFound},
-		{"valid", fmt.Sprintf("cherryservers://%d", server.ID), server.Region.Name, nil},
+		{"valid", fmt.Sprintf("cherryservers://%d", server.ID), server.Region.Slug, nil},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Use slugs instead of full names for regions. I'm not sure if this metadata is used anywhere else, but this does seem to fix the node sync errors. Fixes https://github.com/cherryservers/cloud-provider-cherry/issues/217.