### PR TITLE
more automated integration tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -93,7 +93,7 @@ Deploying metallb is describe on the [metallb home page](https://metallb.univers
 As of this writing, the only thing you need to do is:
 
 ```sh
-METALLB_VERSION=$(curl -sL https://api.github.com/repos/metallb/metallb/releases | jq -r ".[0].name")
+METALLB_VERSION=$(curl -sL https://api.github.com/repos/metallb/metallb/releases | jq -r ".[0].tag_name")
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml
 ```
 

--- a/test/manifests/ccm-test-deployment.yaml
+++ b/test/manifests/ccm-test-deployment.yaml
@@ -144,6 +144,25 @@ rules:
   - update
   - patch
 - apiGroups:
+  # reason: so ccm can work with metallb CRDs
+  - "metallb.io"
+  resources:
+  - bgppeers
+  - bgppeers/status
+  - bgpadvertisements
+  - bgpadvertisements/status
+  - l2advertisements
+  - l2advertisements/status
+  - ipaddresspools
+  - ipaddresspools/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
   # reason: so ccm can read and update events
   - ""
   resources:

--- a/test/manifests/nginx-1.yaml
+++ b/test/manifests/nginx-1.yaml
@@ -1,0 +1,34 @@
+# manifest with a Deployment of nginx and a Service of type=loadbalancer. Useful for testing the load-balancer functionality of CCM.
+# 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-1-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx-1
+  replicas: 1 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx-1
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-1
+spec:
+  selector:
+    app: nginx-1
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/test/manifests/nginx-2.yaml
+++ b/test/manifests/nginx-2.yaml
@@ -3,16 +3,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: nginx-2-deployment
 spec:
   selector:
     matchLabels:
-      app: nginx
+      app: nginx-2
   replicas: 1 # tells deployment to run 2 pods matching the template
   template:
     metadata:
       labels:
-        app: nginx
+        app: nginx-2
     spec:
       containers:
       - name: nginx
@@ -23,10 +23,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx
+  name: nginx-2
 spec:
   selector:
-    app: nginx
+    app: nginx-2
   type: LoadBalancer
   ports:
     - protocol: TCP


### PR DESCRIPTION
Extended the `test.sh` to include some load balancer tests. This thing gets real ugly as a script, which is why I really want @caliban0 's go code in his `e2e-tests` branch to be integrated. But this made it a bit easier for me to run some tests, and therefore likely will help him when he needs to work with it. It does solve a lot of automation problems, which should be useful to him:

- kubernetes bootstraping of nodes
- deploying a CCM that is not yet published on a registry
- determining state of nodes and services
- determining what nodes to use

I don't know if I will get any more done on this one. It should have kube-vip added at least, but it is a bit out of scope for what I need to do. Maybe I will clean it up to have some functions, so it is not quite as ugly..

#236 basically is ready to go in, so it will merge and get tagged.

cc @zalmarge 

