### PR TITLE
fix: parse config for api server port as 32 bit int

### DIFF
--- a/cherry/config.go
+++ b/cherry/config.go
@@ -160,7 +160,7 @@ func getConfig(providerConfig io.Reader) (Config, error) {
 	apiServer := os.Getenv(envVarAPIServerPort)
 	switch {
 	case apiServer != "":
-		apiServerNo, err := strconv.Atoi(apiServer)
+		apiServerNo, err := strconv.ParseInt(apiServer, 10, 32)
 		if err != nil {
 			return config, fmt.Errorf("env var %s must be a number, was %s: %w", envVarAPIServerPort, apiServer, err)
 		}


### PR DESCRIPTION
CodeQL is complaining about possible overflow from jamming a 64 bit integer into 32 bits. This isn't a big deal here, because the config in question is for ports, but this is the correct way of doing things.