### PR TITLE
feat: add 'frr' and 'none' bgp peering modes for metallb

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,14 +331,22 @@ to route traffic for your services at the Floating IP to the correct host.
 To enable it, set the configuration `CHERRY_LOAD_BALANCER` or config `loadbalancer` to:
 
 ```
-metallb:///<metalNamespace>/
+metallb:///<metalNamespace>/?bgp-peer-mode=[frr|native|none]
 ```
+
+The difference between `native` and `frr` modes is mainly `BGPPeer` management:
+* With `native`, separate peers are created for each node.
+* With `frr`, peers are created per region and matched with nodes, based on those regions.
+* With `none`, `BGPPeer` management by the CCM is disable entirely.
+
+The default mode is `native`.
 
 For example:
 
 * `metallb:///metallb-system/` - enable `MetalLB` management and update of the CRDs in the namespace `metallb-system`
 * `metallb:///foonamespace/` -  - enable `MetalLB` management and update of the CRDs in the namespace `foonamespae`
 * `metallb:///` - enable `MetalLB` management and update of the CRDs in the default namespace, i.e. `metallb-system`
+* `metallb:///?mode=frr` - enable `MetalLB` management and update of the CRDs in the default namespace, i.e. `metallb-system`, with FRR mode.
 
 Notice the **three* slashes. In the URL, the namespace is in the path.
 
@@ -349,18 +357,18 @@ When enabled, CCM controls the loadbalancer by updating the CRDs.
 If `MetalLB` management is enabled, then CCM does the following.
 
 1. Get the appropriate namespace, based on the rules above.
-1. Enable BGP on the Cherry Servers project
-1. For each node currently in the cluster or added:
+2. Enable BGP on the Cherry Servers project
+3. For each node currently in the cluster or added:
    * retrieve the node's Cherry Server ID via the node provider ID
    * retrieve the device's BGP configuration: node ASN, peer ASN, peer IPs, source IP
    * add them to the metallb CRDs with a kubernetes selector ensuring that the peer is only for this node
-1. For each node deleted from the cluster:
+4. For each node deleted from the cluster:
    * remove the node from the MetalLB CRDs
-1. For each service of `type=LoadBalancer` currently in the cluster or added:
+5. For each service of `type=LoadBalancer` currently in the cluster or added:
    * if a Floating IP address reservation with the appropriate tags exists, and the `Service` already has that IP address affiliated with it, it is ready; ignore
    * if a Floating IP address reservation with the appropriate tags exists, and the `Service` does not have that IP affiliated with it, add it to the [service spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#servicespec-v1-core) and ensure it is in the pools of the MetalLB CRDs with `auto-assign: false`
    * if a Floating IP address reservation with the appropriate tags does not exist, create it and add it to the services spec, and ensure it is in the pools of the MetalLB CRDs with `auto-assign: false`
-1. For each service of `type=LoadBalancer` deleted from the cluster:
+6. For each service of `type=LoadBalancer` deleted from the cluster:
    * find the Floating IP address from the service spec and remove it
    * remove the IP from the CRDs
    * delete the Floating IP reservation from Cherry Servers

--- a/cherry/loadbalancers.go
+++ b/cherry/loadbalancers.go
@@ -78,7 +78,18 @@ func newLoadBalancers(client *cherrygo.Client, k8sclient kubernetes.Interface, p
 		impl = kubevip.NewLB(k8sclient, lbconfig)
 	case "metallb":
 		klog.Info("loadbalancer implementation enabled: metallb")
-		impl = metallb.NewLB(k8sclient, lbconfig)
+		namespace, bgpPeerMode, err := metallb.ParseConfigURL(u)
+		if err != nil {
+			return nil, fmt.Errorf("invalid metallb config: %w", err)
+		}
+
+		apiNodeSelector, err := metav1.ParseToLabelSelector(nodeSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse node selector %q: %w", nodeSelector, err)
+		}
+
+		peersFromNodes := metallb.NewPeersFromNodesFunc(bgpPeerMode, *apiNodeSelector)
+		impl = metallb.NewLB(k8sclient, namespace, peersFromNodes)
 	case "empty":
 		klog.Info("loadbalancer implementation enabled: empty, bgp only")
 		impl = empty.NewLB(k8sclient, lbconfig)
@@ -204,6 +215,7 @@ func (l *loadBalancers) UpdateLoadBalancer(ctx context.Context, _ string, servic
 			LocalASN: bgpConfig.LocalASN,
 			PeerASN:  bgpConfig.RemoteASN,
 			Peers:    peers,
+			Region:   nodeRegion(node),
 		})
 	}
 	return l.implementor.UpdateService(ctx, service.Namespace, service.Name, n)
@@ -436,10 +448,22 @@ func (l *loadBalancers) addService(ctx context.Context, svc *v1.Service, ips []c
 			LocalASN: bgpConfig.LocalASN,
 			PeerASN:  bgpConfig.RemoteASN,
 			Peers:    peers,
+			Region:   nodeRegion(node),
 		})
 	}
 
 	return svcIPCidr, l.implementor.AddService(ctx, svc.Namespace, svc.Name, svcIPCidr, n)
+}
+
+func nodeRegion(n *v1.Node) string {
+	return nodeLabel(n, "topology.kubernetes.io/region")
+}
+
+func nodeLabel(n *v1.Node, label string) string {
+	if n == nil || n.ObjectMeta.Labels == nil {
+		return ""
+	}
+	return n.ObjectMeta.Labels[label]
 }
 
 func serviceRep(svc *v1.Service) string {

--- a/cherry/loadbalancers/metallb/bgp_peers.go
+++ b/cherry/loadbalancers/metallb/bgp_peers.go
@@ -1,0 +1,183 @@
+package metallb
+
+import (
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/cherryservers/cloud-provider-cherry/cherry/loadbalancers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	hostnameKey = "kubernetes.io/hostname"
+	regionKey   = "topology.kubernetes.io/region"
+	holdTime    = "30s"
+)
+
+// BGPPeerMode defines the available BGP peering modes for the CCM.
+type BGPPeerMode int
+
+func (m BGPPeerMode) String() string {
+	switch m {
+	case BGPPeerModeNone:
+		return "none"
+	case BGPPeerModeNative:
+		return "native"
+	case BGPPeerModeFRR:
+		return "frr"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// BGPPeerModeNone disables CCM managed BGPPeers entirely.
+	BGPPeerModeNone BGPPeerMode = iota
+
+	// BGPPeerModeNative is the native-compatible BGP peering mode.
+	BGPPeerModeNative
+
+	// BGPPeerModeFRR is the FRR-compatible BGP peering mode.
+	BGPPeerModeFRR
+)
+
+// ParseConfigURL parses the namespace and BGP peering mode
+// from a metallb configuration URL. If not configured,
+// native BGP peering mode will be used.
+func ParseConfigURL(config *url.URL) (
+	namespace string, mode BGPPeerMode, err error) {
+	namespace = config.Path
+
+	// May have an extra slash at the beginning or end, so get rid of it.
+	namespace = strings.TrimPrefix(namespace, "/")
+	namespace = strings.TrimSuffix(namespace, "/")
+
+	rawMode := config.Query().Get("bgp-peer-mode")
+	switch rawMode {
+	case "native":
+		mode = BGPPeerModeNative
+	case "frr":
+		mode = BGPPeerModeFRR
+	case "none":
+		mode = BGPPeerModeNone
+	case "":
+		mode = BGPPeerModeNative
+	default:
+		return namespace, BGPPeerModeNative,
+			fmt.Errorf("invalid 'bgp-peer-mode' parameter: %q", rawMode)
+	}
+
+	return namespace, mode, nil
+}
+
+// NewPeersFromNodesFunc builds the appropriate PeersFromNodesFunc, based on
+// the BGPPeerMode. `nodeSelectors` will be merged with the BGPPeer's NodeSelectors,
+// when in FRR mode. This is not required for native mode, since each node gets
+// separate BGPPeers.
+func NewPeersFromNodesFunc(mode BGPPeerMode, nodeSelectors metav1.LabelSelector,
+) PeersFromNodesFunc {
+	switch mode {
+	case BGPPeerModeFRR:
+		return NewPeersFromNodesFRRFunc(nodeSelectors)
+	case BGPPeerModeNative:
+		return PeersFromNodesNative
+	case BGPPeerModeNone:
+		return PeersFromNodesNone
+	default:
+		return PeersFromNodesNative
+	}
+}
+
+// PeersFromNodesFunc builds a list of peers for the provided nodes.
+type PeersFromNodesFunc func(nodes []loadbalancers.Node) []Peer
+
+// PeersFromNodesNone always returns a nil slice.
+func PeersFromNodesNone(_ []loadbalancers.Node) []Peer {
+	return nil
+}
+
+// PeersFromNodesNative builds a list of peers for the provided nodes.
+// Each node gets a distinct peer object for each of it's possible peers.
+// This makes it incompatible with metallb's FRR mode, since BGPPeers
+// with duplicate destination IPs are not allowed.
+func PeersFromNodesNative(nodes []loadbalancers.Node) []Peer {
+	var peers []Peer
+	for _, node := range nodes {
+		ns := []NodeSelector{{MatchLabels: map[string]string{
+			hostnameKey: node.Name,
+		}}}
+		for i, peer := range node.Peers {
+			p := Peer{
+				MyASN:         uint32(node.LocalASN),
+				ASN:           uint32(node.PeerASN),
+				Password:      node.Password,
+				Addr:          peer.Address,
+				Port:          uint16(peer.Port),
+				SrcAddr:       node.SourceIP,
+				HoldTime:      holdTime,
+				NodeSelectors: ns,
+				Name:          fmt.Sprintf("%s-%d", node.Name, i),
+			}
+			peers = append(peers, p)
+		}
+	}
+	return peers
+}
+
+// Unfortunately, `convertToNodeSelector` already exists.
+func convertToMetalLBNodeSelector(ls metav1.LabelSelector) NodeSelector {
+	selectorReqs := make([]SelectorRequirements, len(ls.MatchExpressions))
+	for i, req := range ls.MatchExpressions {
+		selectorReqs[i] = SelectorRequirements{
+			Key:      req.Key,
+			Operator: string(req.Operator),
+			Values:   req.Values,
+		}
+	}
+	ns := NodeSelector{MatchLabels: ls.MatchLabels, MatchExpressions: selectorReqs}
+	return ns
+}
+
+// NewPeersFromNodesFFRFunc builds a FRR mode-compatible PeersFromNodesFunc.
+//
+// In contrast to PeersFromNodesNative, the peer slice built from this function
+// will not have duplicate peers. Instead, peers will have node selectors based on the
+// node region label, merged with the provided `nodeSelector`.
+//
+// Also, ebgpMultiHop will be enabled for every peer, as this is required in FRR mode.
+func NewPeersFromNodesFRRFunc(nodeSelector metav1.LabelSelector) PeersFromNodesFunc {
+	ns := convertToMetalLBNodeSelector(nodeSelector)
+	return func(nodes []loadbalancers.Node) []Peer {
+		peers := make(map[string]Peer)
+		for _, node := range nodes {
+			nsDup := ns.Duplicate()
+			nsDup.MatchLabels[regionKey] = node.Region
+			for i, peer := range node.Peers {
+				p := Peer{
+					MyASN:         uint32(node.LocalASN),
+					ASN:           uint32(node.PeerASN),
+					Addr:          peer.Address,
+					Port:          uint16(peer.Port),
+					HoldTime:      holdTime,
+					EBGPMultiHop:  true,
+					NodeSelectors: []NodeSelector{nsDup},
+					// Region slugs start with an upper case country code,
+					// so a conversion to lower case is needed.
+					Name: strings.ToLower(fmt.Sprintf("%s-%d", node.Region, i)),
+				}
+				peers[p.Name] = p
+			}
+		}
+		return slices.SortedFunc(maps.Values(peers), func(a, b Peer) int {
+			if a.Name < b.Name {
+				return -1
+			} else if a.Name > b.Name {
+				return 1
+			}
+			return 0
+		})
+	}
+}

--- a/cherry/loadbalancers/metallb/bgp_peers_test.go
+++ b/cherry/loadbalancers/metallb/bgp_peers_test.go
@@ -1,0 +1,430 @@
+package metallb
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/cherryservers/cloud-provider-cherry/cherry/loadbalancers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func assertPeersEqual(t *testing.T, got, want []Peer) {
+	if len(got) != len(want) {
+		t.Fatalf("got %d peers, want %d", len(got), len(want))
+	}
+
+	for i := range got {
+		if got[i].MyASN != want[i].MyASN {
+			t.Errorf("MyASN: %d, want: %d, peer index %d", got[i].MyASN, want[i].MyASN, i)
+		}
+		if got[i].ASN != want[i].ASN {
+			t.Errorf("ASN: %d, want: %d, peer index %d", got[i].ASN, want[i].ASN, i)
+		}
+		if got[i].Addr != want[i].Addr {
+			t.Errorf("Addr: %q, want: %q, peer index %d", got[i].Addr, want[i].Addr, i)
+		}
+		if got[i].Port != want[i].Port {
+			t.Errorf("Port: %d, want: %d, peer index %d", got[i].Port, want[i].Port, i)
+		}
+		if got[i].SrcAddr != want[i].SrcAddr {
+			t.Errorf("SrcAddr: %q, want: %q, peer index %d",
+				got[i].SrcAddr, want[i].SrcAddr, i)
+		}
+		if got[i].HoldTime != want[i].HoldTime {
+			t.Errorf("HoldTime: %q, want: %q, peer index %d",
+				got[i].HoldTime, want[i].HoldTime, i)
+		}
+		if got[i].RouterID != want[i].RouterID {
+			t.Errorf("RouterID: %q, want: %q, peer index %d",
+				got[i].RouterID, want[i].RouterID, i)
+		}
+		if !reflect.DeepEqual(got[i].NodeSelectors, want[i].NodeSelectors) {
+			t.Errorf("NodeSelectors: %+v, want: %+v, peer index %d",
+				got[i].NodeSelectors, want[i].NodeSelectors, i)
+		}
+		if got[i].Password != want[i].Password {
+			t.Errorf("Password: %q, want: %q, peer index %d",
+				got[i].Password, want[i].Password, i)
+		}
+		if got[i].Name != want[i].Name {
+			t.Errorf("Name: %q, want: %q, peer index %d", got[i].Name, want[i].Name, i)
+		}
+	}
+}
+
+func TestPeersFromNodesNative(t *testing.T) {
+	const labelKey = "kubernetes.io/hostname"
+
+	tests := []struct {
+		title string
+		nodes []loadbalancers.Node
+		peers []Peer
+	}{
+		{title: "empty", nodes: []loadbalancers.Node{}, peers: nil},
+		{title: "single node",
+			nodes: []loadbalancers.Node{
+				{
+					Name:     "test-name",
+					SourceIP: "127.0.0.1",
+					LocalASN: 12345,
+					PeerASN:  23456,
+					Password: "test-password",
+					Peers: []loadbalancers.Peer{
+						{Address: "46.166.166.122", Port: 179},
+						{Address: "46.166.166.123", Port: 180},
+					},
+					Region: "test-region",
+				},
+			}, peers: []Peer{
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.122",
+					Port:          179,
+					SrcAddr:       "127.0.0.1",
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: []NodeSelector{{MatchLabels: map[string]string{labelKey: "test-name"}}},
+					Password:      "test-password",
+					Name:          "test-name-0",
+				},
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.123",
+					Port:          180,
+					SrcAddr:       "127.0.0.1",
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: []NodeSelector{{MatchLabels: map[string]string{labelKey: "test-name"}}},
+					Password:      "test-password",
+					Name:          "test-name-1",
+				},
+			}},
+		{title: "multi node",
+			nodes: []loadbalancers.Node{
+				{
+					Name:     "test-first-name",
+					SourceIP: "127.0.0.1",
+					LocalASN: 12345,
+					PeerASN:  23456,
+					Password: "test-first-password",
+					Peers: []loadbalancers.Peer{
+						{Address: "46.166.166.122", Port: 179},
+						{Address: "46.166.166.123", Port: 180},
+					},
+					Region: "test-first-region",
+				},
+				{
+					Name:     "test-second-name",
+					SourceIP: "127.0.0.2",
+					LocalASN: 34567,
+					PeerASN:  45678,
+					Password: "test-second-password",
+					Peers: []loadbalancers.Peer{
+						{Address: "195.189.96.10", Port: 179},
+						{Address: "195.189.96.11", Port: 180},
+					},
+					Region: "test-second-region",
+				},
+			}, peers: []Peer{
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.122",
+					Port:          179,
+					SrcAddr:       "127.0.0.1",
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: []NodeSelector{{MatchLabels: map[string]string{labelKey: "test-first-name"}}},
+					Password:      "test-first-password",
+					Name:          "test-first-name-0",
+				},
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.123",
+					Port:          180,
+					SrcAddr:       "127.0.0.1",
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: []NodeSelector{{MatchLabels: map[string]string{labelKey: "test-first-name"}}},
+					Password:      "test-first-password",
+					Name:          "test-first-name-1",
+				},
+				{
+					MyASN:         34567,
+					ASN:           45678,
+					Addr:          "195.189.96.10",
+					Port:          179,
+					SrcAddr:       "127.0.0.2",
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: []NodeSelector{{MatchLabels: map[string]string{labelKey: "test-second-name"}}},
+					Password:      "test-second-password",
+					Name:          "test-second-name-0",
+				},
+				{
+					MyASN:         34567,
+					ASN:           45678,
+					Addr:          "195.189.96.11",
+					Port:          180,
+					SrcAddr:       "127.0.0.2",
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: []NodeSelector{{MatchLabels: map[string]string{labelKey: "test-second-name"}}},
+					Password:      "test-second-password",
+					Name:          "test-second-name-1",
+				},
+			}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := PeersFromNodesNative(tt.nodes)
+			want := tt.peers
+
+			assertPeersEqual(t, got, want)
+		})
+	}
+}
+
+func TestPeersFromNodesFRR(t *testing.T) {
+	const (
+		hostnameLabelKey = "kubernetes.io/hostname"
+		regionLabelKey   = "topology.kubernetes.io/region"
+	)
+
+	var nodeSelectors = func(region string) []NodeSelector {
+		return []NodeSelector{
+			{MatchLabels: map[string]string{
+				regionLabelKey:   region,
+				hostnameLabelKey: "selector-test"},
+				MatchExpressions: []SelectorRequirements{
+					{Key: hostnameLabelKey,
+						Operator: "In",
+						Values:   []string{"selector-test"},
+					},
+				}}}
+	}
+
+	tests := []struct {
+		title string
+		nodes []loadbalancers.Node
+		peers []Peer
+	}{
+		{title: "empty", nodes: []loadbalancers.Node{}, peers: nil},
+		{title: "single node",
+			nodes: []loadbalancers.Node{
+				{
+					Name:     "test-name",
+					LocalASN: 12345,
+					PeerASN:  23456,
+					Peers: []loadbalancers.Peer{
+						{Address: "46.166.166.122", Port: 179},
+						{Address: "46.166.166.123", Port: 180},
+					},
+					Region: "test-region",
+				},
+			}, peers: []Peer{
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.122",
+					Port:          179,
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: nodeSelectors("test-region"),
+					Name:          "test-region-0",
+					EBGPMultiHop:  true,
+				},
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.123",
+					Port:          180,
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: nodeSelectors("test-region"),
+					Name:          "test-region-1",
+					EBGPMultiHop:  true,
+				},
+			}},
+		{title: "multi node",
+			nodes: []loadbalancers.Node{
+				{
+					Name:     "test-first-name",
+					LocalASN: 12345,
+					PeerASN:  23456,
+					Peers: []loadbalancers.Peer{
+						{Address: "46.166.166.122", Port: 179},
+						{Address: "46.166.166.123", Port: 180},
+					},
+					Region: "test-first-region",
+				},
+				{
+					Name:     "test-second-name",
+					LocalASN: 34567,
+					PeerASN:  45678,
+					Peers: []loadbalancers.Peer{
+						{Address: "195.189.96.10", Port: 179},
+						{Address: "195.189.96.11", Port: 180},
+					},
+					Region: "test-second-region",
+				},
+				{
+					Name:     "test-third-name",
+					LocalASN: 34567,
+					PeerASN:  45678,
+					Peers: []loadbalancers.Peer{
+						{Address: "195.189.96.10", Port: 179},
+						{Address: "195.189.96.11", Port: 180},
+					},
+					Region: "test-second-region",
+				},
+			}, peers: []Peer{
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.122",
+					Port:          179,
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: nodeSelectors("test-first-region"),
+					Name:          "test-first-region-0",
+					EBGPMultiHop:  true,
+				},
+				{
+					MyASN:         12345,
+					ASN:           23456,
+					Addr:          "46.166.166.123",
+					Port:          180,
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: nodeSelectors("test-first-region"),
+					Name:          "test-first-region-1",
+					EBGPMultiHop:  true,
+				},
+				{
+					MyASN:         34567,
+					ASN:           45678,
+					Addr:          "195.189.96.10",
+					Port:          179,
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: nodeSelectors("test-second-region"),
+					Name:          "test-second-region-0",
+					EBGPMultiHop:  true,
+				},
+				{
+					MyASN:         34567,
+					ASN:           45678,
+					Addr:          "195.189.96.11",
+					Port:          180,
+					HoldTime:      holdTime,
+					RouterID:      "",
+					NodeSelectors: nodeSelectors("test-second-region"),
+					Name:          "test-second-region-1",
+					EBGPMultiHop:  true,
+				},
+			}},
+	}
+
+	ls, err := metav1.ParseToLabelSelector(
+		"kubernetes.io/hostname==selector-test," +
+			"kubernetes.io/hostname in (selector-test)")
+	if err != nil {
+		t.Fatalf("invalid label selector: %v", err)
+	}
+	f := NewPeersFromNodesFRRFunc(*ls)
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := f(tt.nodes)
+			want := tt.peers
+
+			assertPeersEqual(t, got, want)
+		})
+	}
+}
+
+func TestParseConfigURL(t *testing.T) {
+	tests := []struct {
+		rawConfig string
+		namespace string
+		mode      BGPPeerMode
+		err       error
+	}{
+		{
+			rawConfig: "metallb:///",
+			namespace: "",
+			mode:      BGPPeerModeNative,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///foonamespace/",
+			namespace: "foonamespace",
+			mode:      BGPPeerModeNative,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///?bgp-peer-mode=frr",
+			namespace: "",
+			mode:      BGPPeerModeFRR,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///test?bgp-peer-mode=frr",
+			namespace: "test",
+			mode:      BGPPeerModeFRR,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///?bgp-peer-mode=native",
+			namespace: "",
+			mode:      BGPPeerModeNative,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///test?bgp-peer-mode=native",
+			namespace: "test",
+			mode:      BGPPeerModeNative,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///?bgp-peer-mode=none",
+			namespace: "",
+			mode:      BGPPeerModeNone,
+			err:       nil,
+		},
+		{
+			rawConfig: "metallb:///test?bgp-peer-mode=none",
+			namespace: "test",
+			mode:      BGPPeerModeNone,
+			err:       nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.rawConfig, func(t *testing.T) {
+			url, err := url.Parse(tt.rawConfig)
+			if err != nil {
+				t.Fatalf("invalid metallb config url: %s", tt.rawConfig)
+			}
+
+			namespace, mode, err := ParseConfigURL(url)
+
+			if err != tt.err {
+				t.Errorf("error: %q, want %q", err, tt.err)
+			}
+
+			if namespace != tt.namespace {
+				t.Errorf("namespace: %q, want %q", namespace, tt.namespace)
+			}
+
+			if mode != tt.mode {
+				t.Errorf("bgp peer mode: %q, want %q", mode, tt.mode)
+			}
+		})
+	}
+}

--- a/cherry/loadbalancers/metallb/config.go
+++ b/cherry/loadbalancers/metallb/config.go
@@ -43,6 +43,7 @@ type Peer struct {
 	RouterID      string         `yaml:"router-id"`
 	NodeSelectors []NodeSelector `yaml:"node-selectors"`
 	Password      string         `yaml:"password"`
+	EBGPMultiHop  bool           `yaml:"ebgp-multi-hop"`
 	Name          string         `json:"name,omitempty"`
 }
 

--- a/cherry/loadbalancers/metallb/crd.go
+++ b/cherry/loadbalancers/metallb/crd.go
@@ -484,7 +484,7 @@ func convertToBGPPeer(peer Peer, namespace, svc string) metalapi.BGPPeer {
 			NodeSelectors: convertToNodeSelectors(peer.NodeSelectors),
 			Password:      peer.Password,
 			// BFDProfile:
-			// EBGPMultiHop:
+			EBGPMultiHop: peer.EBGPMultiHop,
 		},
 	}
 	bgpPeer.SetLabels(map[string]string{cpemLabelKey: cpemLabelValue})

--- a/cherry/loadbalancers/metallb/metallb.go
+++ b/cherry/loadbalancers/metallb/metallb.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/cherryservers/cloud-provider-cherry/cherry/loadbalancers"
 	metalapi "go.universe.tf/metallb/api/v1beta1"
@@ -16,7 +15,6 @@ import (
 )
 
 const (
-	hostnameKey         = "kubernetes.io/hostname"
 	serviceNameKey      = "nomatch.cherryservers.com/service-name"
 	serviceNameSpaceKey = "nomatch.cherryservers.com/service-namespace"
 	defaultNamespace    = "metallb-system"
@@ -53,7 +51,8 @@ type Configurer interface {
 }
 
 type LB struct {
-	configurer Configurer
+	configurer     Configurer
+	peersFromNodes PeersFromNodesFunc
 }
 
 // NewLB returns a new LB
@@ -61,12 +60,7 @@ type LB struct {
 // We keep it around in case it is needed in the future, e.g. if we need to go back to the configmap.
 // In theory, we should be able to get the client we need of type "sigs.k8s.io/controller-runtime/pkg/client"
 // from the k8sclient; for the future.
-func NewLB(_ kubernetes.Interface, config string) *LB {
-	// may have an extra slash at the beginning or end, so get rid of it
-	config = strings.TrimPrefix(config, "/")
-	config = strings.TrimSuffix(config, "/")
-	namespace := config
-
+func NewLB(_ kubernetes.Interface, namespace string, peersFromNodes PeersFromNodesFunc) *LB {
 	// default
 	if namespace == "" {
 		namespace = defaultNamespace
@@ -80,7 +74,8 @@ func NewLB(_ kubernetes.Interface, config string) *LB {
 		panic(err)
 	}
 	return &LB{
-		configurer: &CRDConfigurer{namespace: namespace, client: cl},
+		configurer:     &CRDConfigurer{namespace: namespace, client: cl},
+		peersFromNodes: peersFromNodes,
 	}
 }
 
@@ -142,30 +137,7 @@ func (l *LB) addNodes(ctx context.Context, svcNamespace, svcName string, nodes [
 		return fmt.Errorf("unable to get metallb config: %w", err)
 	}
 
-	var (
-		changed       bool
-		peersToUpdate []Peer
-	)
-	for _, node := range nodes {
-		ns := []NodeSelector{
-			{MatchLabels: map[string]string{
-				hostnameKey: node.Name,
-			}},
-		}
-		for i, peer := range node.Peers {
-			p := Peer{
-				MyASN:         uint32(node.LocalASN),
-				ASN:           uint32(node.PeerASN),
-				Password:      node.Password,
-				Addr:          peer.Address,
-				Port:          uint16(peer.Port),
-				SrcAddr:       node.SourceIP,
-				NodeSelectors: ns,
-				Name:          fmt.Sprintf("%s-%d", node.Name, i),
-			}
-			peersToUpdate = append(peersToUpdate, p)
-		}
-	}
+	peersToUpdate := l.peersFromNodes(nodes)
 	// to ensure that the nodes are correct, we need to check the nodes specified
 	// for these services against the whole list of nodes/peers saved in the configuration
 	changed, err := config.UpdatePeersByService(ctx, &peersToUpdate, svcNamespace, svcName)

--- a/cherry/loadbalancers/node.go
+++ b/cherry/loadbalancers/node.go
@@ -7,6 +7,7 @@ type Node struct {
 	PeerASN  int
 	Password string
 	Peers    []Peer
+	Region   string
 }
 
 type Peer struct {


### PR DESCRIPTION
To work with metallb in FRR mode,the CCM's `?bgp-peer-mode=frr` mode makes the following changes to how BGPPeers are managed:
1. Enable `ebgpMultiHop` for all peers.
2. Create peers on a per-region basis, instead of each node getting separate BGPPeer objects.

`?bgp-peer-mode=none` disables CCM's BGPPeer management entirely.

`?bgp-peer-mode=native` is the default and behaves as before, except for the `holdTime` being set to 30s, instead of 0 (this applies to all modes), which should improve session stability.

I considered getting rid of per-node BGP peering, but we may want to use `sourceAddress` in the future.

Fixes https://github.com/cherryservers/cloud-provider-cherry/issues/264.

This will be back-ported to all supported versions (1.34, 1.33 and 1.32).