### PR TITLE
Automate back-porting with GitHub Actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,20 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    # Only run on merged PRs.
+    if: github.event.pull_request.merged
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Create backport pull requests
+        uses: korthout/backport-action@01619ebc9a6e3f6820274221b9956b3e7365000a # v4.1.0

--- a/BUILD.md
+++ b/BUILD.md
@@ -205,6 +205,10 @@ This branch is used for all patches to that `major.minor` version.
 
 When a new patch is required for a `vX.Y` branch, apply the fix to the HEAD of the specific branch.
 
+To simplify back-porting to version branches, use `backport vX.Y` labels.
+Then, if the original pull request is merged, pull requests to `vX.Y` branches,
+with cherry-picked commits, will be automatically opened.
+
 ### Cutting a Release
 
 To cut a release, tag a commit on the branch. The tag should be of the form `vX.Y.Z`,


### PR DESCRIPTION
This enables the use of labels to automate PR creation for features/fixes that need to be backported to different version branches.

I also tried permitting auto-merging if the right label is set (https://github.com/marketplace/actions/backport-merged-pull-requests-to-selected-branches#auto_merge_enabled), but it seems that requires protection rules to be set for each branch, so let's skip it for now.