### PR TITLE
Add load balancer source IPs

### DIFF
--- a/cherry/bgp.go
+++ b/cherry/bgp.go
@@ -15,6 +15,7 @@ type BGPPeer struct {
 	Port    int
 }
 type NodeBGPInfo struct {
+	SourceIP  string
 	LocalASN  int
 	RemoteASN int
 	Peers     []BGPPeer
@@ -83,14 +84,12 @@ func (b *bgp) ensureNodeBGPEnabled(providerID string) (NodeBGPInfo, error) {
 	if err != nil {
 		return NodeBGPInfo{}, fmt.Errorf("error getting server %d: %v", id, err)
 	}
-	// already configured? just return nil
+
+	// Server update requests don't return IP address fields, so save the IPs.
+	ips := server.IPAddresses
+
 	if server.BGP.Enabled {
-		// get the BGP info on the server
-		var peers []BGPPeer
-		for _, p := range server.Region.BGP.Hosts {
-			peers = append(peers, BGPPeer{Address: p, Port: PeerPort})
-		}
-		return NodeBGPInfo{LocalASN: b.localASN, RemoteASN: server.Region.BGP.Asn, Peers: peers}, nil
+		return b.nodeBGPInfoFromServer(server)
 	}
 
 	// enable it
@@ -101,10 +100,31 @@ func (b *bgp) ensureNodeBGPEnabled(providerID string) (NodeBGPInfo, error) {
 	if err != nil {
 		return NodeBGPInfo{}, err
 	}
-	// get the BGP info on the server
-	var peers []BGPPeer
-	for _, p := range server.Region.BGP.Hosts {
-		peers = append(peers, BGPPeer{Address: p, Port: PeerPort})
+
+	server.IPAddresses = ips
+	return b.nodeBGPInfoFromServer(server)
+}
+
+func (b *bgp) nodeBGPInfoFromServer(s cherrygo.Server) (NodeBGPInfo, error) {
+	ips, err := ipsFromServer(s)
+	if err != nil {
+		// Might not have failed to parse every IP, so just log and try to continue.
+		klog.V(2).Infof("failed to parse server %d ips: %v", s.ID, err)
 	}
-	return NodeBGPInfo{LocalASN: b.localASN, RemoteASN: server.Region.BGP.Asn, Peers: peers}, nil
+
+	sourceIP, err := ips.anyPublic4()
+	if err != nil {
+		return NodeBGPInfo{}, fmt.Errorf("no public IP for server %d: %w", s.ID, err)
+	}
+
+	var peers []BGPPeer
+	for _, a := range s.Region.BGP.Hosts {
+		peers = append(peers, BGPPeer{Address: a, Port: PeerPort})
+	}
+
+	return NodeBGPInfo{
+		LocalASN:  b.localASN,
+		RemoteASN: s.Region.BGP.Asn,
+		Peers:     peers,
+		SourceIP:  sourceIP.String()}, nil
 }

--- a/cherry/instances.go
+++ b/cherry/instances.go
@@ -92,33 +92,36 @@ func (i *instances) InstanceMetadata(_ context.Context, node *v1.Node) (*cloudpr
 }
 
 func nodeAddresses(server cherrygo.Server) ([]v1.NodeAddress, error) {
-	var addresses []v1.NodeAddress
-	addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: server.Hostname})
-
-	var privateIP, publicIP string
-	for _, address := range server.IPAddresses {
-		if address.AddressFamily == 4 {
-			var addrType v1.NodeAddressType
-			switch address.Type {
-			case "private-ip":
-				privateIP = address.Address
-				addrType = v1.NodeInternalIP
-			case "primary-ip", "public-ip":
-				publicIP = address.Address
-				addrType = v1.NodeExternalIP
-			}
-			addresses = append(addresses, v1.NodeAddress{Type: addrType, Address: address.Address})
-		}
+	ips, err := ipsFromServer(server)
+	if err != nil {
+		// Might not have failed to parse every IP, so just log and try to continue.
+		klog.V(2).Infof("failed to parse server %d ips: %v", server.ID, err)
 	}
 
-	if privateIP == "" {
+	pub, pri := ips.allPublic4(), ips.allPrivate4()
+
+	if len(pri) < 1 {
 		return nil, errors.New("could not get at least one private ip")
 	}
 
-	if publicIP == "" {
+	if len(pub) < 1 {
 		return nil, errors.New("could not get at least one public ip")
 	}
 
+	addresses := make([]v1.NodeAddress, 0, len(pub)+len(pri)+1)
+	addresses = append(addresses,
+		v1.NodeAddress{Type: v1.NodeHostName, Address: server.Hostname})
+
+	for _, ip := range pub {
+		addresses = append(addresses,
+			v1.NodeAddress{Type: v1.NodeExternalIP, Address: ip.String()})
+	}
+
+	for _, ip := range pri {
+		addresses = append(addresses,
+			v1.NodeAddress{Type: v1.NodeInternalIP, Address: ip.String()})
+
+	}
 	return addresses, nil
 }
 

--- a/cherry/loadbalancers.go
+++ b/cherry/loadbalancers.go
@@ -237,6 +237,7 @@ func (l *loadBalancers) UpdateLoadBalancer(ctx context.Context, _ string, servic
 			PeerASN:  bgpConfig.RemoteASN,
 			Peers:    peers,
 			Region:   nodeRegion(node),
+			SourceIP: bgpConfig.SourceIP,
 		})
 	}
 	return l.implementor.UpdateService(ctx, service.Namespace, service.Name, n)
@@ -477,6 +478,7 @@ func (l *loadBalancers) addService(ctx context.Context, svc *v1.Service, ips []c
 			PeerASN:  bgpConfig.RemoteASN,
 			Peers:    peers,
 			Region:   nodeRegion(node),
+			SourceIP: bgpConfig.SourceIP,
 		})
 	}
 

--- a/cherry/loadbalancers.go
+++ b/cherry/loadbalancers.go
@@ -336,10 +336,12 @@ func (l *loadBalancers) annotateNode(ctx context.Context, node *v1.Node) error {
 			annotationLocalASN := strings.Replace(l.annotationLocalASN, "{{n}}", strconv.Itoa(i), 1)
 			annotationPeerASN := strings.Replace(l.annotationPeerASN, "{{n}}", strconv.Itoa(i), 1)
 			annotationPeerIP := strings.Replace(l.annotationPeerIP, "{{n}}", strconv.Itoa(i), 1)
+			annotationSrcIP := strings.Replace(l.annotationSrcIP, "{{n}}", strconv.Itoa(i), 1)
 
 			annotations[annotationLocalASN] = localASN
 			annotations[annotationPeerASN] = peerASN
 			annotations[annotationPeerIP] = peer.Address
+			annotations[annotationSrcIP] = bgpConfig.SourceIP
 		}
 	}
 

--- a/cherry/server_ip.go
+++ b/cherry/server_ip.go
@@ -1,0 +1,78 @@
+package cherry
+
+import (
+	"errors"
+	"net/netip"
+
+	cherrygo "github.com/cherryservers/cherrygo/v3"
+)
+
+const (
+	serverPublicIPType  = "primary-ip"
+	serverPrivateIPType = "private-ip"
+)
+
+type serverIPs struct {
+	public  []netip.Addr
+	private []netip.Addr
+}
+
+func ipsFromServer(s cherrygo.Server) (serverIPs, error) {
+	// Server most likely has a single public and private IP address.
+	public, private := make([]netip.Addr, 0, 1), make([]netip.Addr, 0, 1)
+	var errs []error
+
+	for _, ip := range s.IPAddresses {
+		addr, err := netip.ParseAddr(ip.Address)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// We don't care about IP types other than "private" and "public" for now.
+		switch ip.Type {
+		case serverPublicIPType:
+			public = append(public, addr)
+		case serverPrivateIPType:
+			private = append(private, addr)
+		}
+	}
+
+	return serverIPs{
+		public:  public,
+		private: private,
+	}, errors.Join(errs...)
+}
+
+func (s serverIPs) anyPublic4() (netip.Addr, error) {
+	for _, ip := range s.public {
+		if ip.Is4() {
+			return ip, nil
+		}
+	}
+	return netip.Addr{}, errors.New("server doesn't have a public IPv4")
+}
+
+func (s serverIPs) allPublic4() []netip.Addr {
+	var pub4 []netip.Addr
+
+	for _, ip := range s.public {
+		if ip.Is4() {
+			pub4 = append(pub4, ip)
+		}
+	}
+
+	return pub4
+}
+
+func (s serverIPs) allPrivate4() []netip.Addr {
+	var pri4 []netip.Addr
+
+	for _, ip := range s.private {
+		if ip.Is4() {
+			pri4 = append(pri4, ip)
+		}
+	}
+
+	return pri4
+}


### PR DESCRIPTION
When ensuring/updating load balancers, get the primary server IP address from the Cherry Servers API and:
* Pass it to load balancer implementations. They may then use that as the node source IP for BGP peering, instead of having to rely on OS defaults.
* Set the `cherryservers.com/bgp-peers-{{n}}-src-ip` node annotation. We already claim to do this in `README.md`.

Also, refactor the `nodeAddresses` function, which is used for instance metadata generation, so that it uses these new utilities for server IP extraction.