### PR TITLE
Omit previously backported pull requests from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release

--- a/BUILD.md
+++ b/BUILD.md
@@ -184,6 +184,9 @@ version branches, use `backport vX.Y` labels - CI will then automatically create
 branches with cherry picked commits. If that fails due to conflicts, cherry pick the needed commits
 by hand and resolve as needed.
 
+When a pull request needs to be merged into main **and** backported to supported versions, the `ignore-for-release` label
+should also be added to the pull request into `main`. This helps keep the release changelog clean on next major release by omitting pull requests that have already been merged into old version branches.
+
 ### Cutting a Release
 
 To cut a release, tag a commit on the branch. The tag should be of the form `vX.Y.Z`,


### PR DESCRIPTION
Add configuration and document instructions for omitting pull requests from the release changelog, when their contents have already been merged into old version branches.

Is this a reasonable addendum to the versioning policy changes discussed in https://github.com/cherryservers/cloud-provider-cherry/pull/296 @deitch?

Closes https://github.com/cherryservers/cloud-provider-cherry/issues/304.