### PR TITLE
Allow unsafe checkout for backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,5 +16,7 @@ jobs:
     if: github.event.pull_request.merged
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          allow-unsafe-pr-checkout: true
       - name: Create backport pull requests
         uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0


### PR DESCRIPTION
`actions/checkout@v7` now requires it. The checkout is safe, because it only runs on merged PRs.